### PR TITLE
Trying to remove Wounded from the token hud gives an error

### DIFF
--- a/scripts/hidden-effects.js
+++ b/scripts/hidden-effects.js
@@ -123,7 +123,7 @@ function ActorPF2E_temporaryEffects_Wrapper (wrapped, ...args) {
  */
 function TokenPF2E_showFloatyText_Wrapper (wrapped, params) {
   const effectData = params.create || params.delete
-  if (!effectData) return wrapped(params)
+  if (!effectData?.flags) return wrapped(params)
   const hidden = effectData.flags[MODULE_ID]?.['hiddenFromPlayer']
   if (!hidden || game.user.isGM || this.document.hidden) return wrapped(params)
 


### PR DESCRIPTION
Discovered it by accident while chasing a bug of my own making, but it also happens when only pf2e-extempore-effects is enabled. To reproduce drag a token onto the canvas, give it wounded from the hud, rightclick to remove hud:
```hidden-effects.js:127 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'pf2e-extempore-effects')
[Detected 3 packages: pf2e-extempore-effects, lib-wrapper, system:pf2e]
    at TokenPF2e.TokenPF2E_showFloatyText_Wrapper (hidden-effects.js:127:34)
    at 🎁call_wrapper [as call_wrapper] (libWrapper-wrapper.js:616:16)```