### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -26,16 +26,16 @@
       "open-effect-sheet-shortcut": {
         "name": "Ouvrir le raccourci de la feuille d'effet",
         "hint": "S'il n'est pas activé, vous pouvez utiliser ceci pour ouvrir la feuille d'effets lorsque vous créez un 'extempore effect' et lorsque vous utilisez le panneau des effets.",
-        "choice_shift_left_click": "Shift + Left-Click",
-        "choice_ctrl_left_click": "Control + Left-Click",
-        "choice_disabled": "Disabled"
+        "choice_shift_left_click": "Shift + Clic gauche",
+        "choice_ctrl_left_click": "Ctrl + clic gauche",
+        "choice_disabled": "Désactivé"
       },
       "notifications-for-expired-effects": {
-        "name": "Notifications for expired events",
-        "hint": "Effects that expire will send a notification and a chat message, as a reminder",
-        "choice_all_effects": "All effects",
-        "choice_only_unidentified": "Only secret (unidentified) effects",
-        "choice_disabled": "Disabled"
+        "name": "Notifications pour les évènements expirés",
+        "hint": "Les effets qui expirent enverront une notification et un message dans la conversation à titre de rappel",
+        "choice_all_effects": "Tous les effets",
+        "choice_only_unidentified": "Seulement les effets secrets (non identifiés)",
+        "choice_disabled": "Désactivé"
       }
     },
     "errorMultipleTokensCustomEffect": "Vous avez besoin d'avoir un objet sélectionné pour appliquer un nouvel effet personnalisé.",


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [pf2E Extempore Effects/main](https://weblate.foundryvtt-hub.com/projects/pf2e-extempore-effects/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/pf2e-extempore-effects/-/main/horizontal-auto.svg)