### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/lang/pl.json
+++ b/lang/pl.json
@@ -31,7 +31,7 @@
       },
       "notifications-for-expired-effects": {
         "name": "Powiadomienia o wygasłych zdarzeniach",
-        "hint": "Efekty, które wygasną, wyślą powiadomienie i wiadomość na czacie, jako przypomnienie",
+        "hint": "Efekty o długim czasie trwania, które wygasną, wyślą powiadomienie i wiadomość na czacie jako przypomnienie",
         "choice_all_effects": "Wszystkie efekty",
         "choice_disabled": "Wyłączony"
       }
@@ -39,6 +39,7 @@
     "contextMenuExtemporeEffect": "Extempore Effect",
     "errorMultipleTokensCustomEffect": "Aby zastosować nowy efekt niestandardowy, należy wybrać jeden token.",
     "errorNoTokensSelected": "Aby zastosować efekt, należy wybrać token(y).",
-    "errorItemNotFound": "Nie znaleziono elementu w wiadomości PF2e."
+    "errorItemNotFound": "Nie znaleziono elementu w wiadomości PF2e.",
+    "stageN": "Etap {n}"
   }
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [pf2E Extempore Effects/main](https://weblate.foundryvtt-hub.com/projects/pf2e-extempore-effects/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widget/pf2e-extempore-effects/main/horizontal-auto.svg)