### PR TITLE
New Features: Stop the Clock & Sound notifications

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -37,10 +37,44 @@
         "choice_all_effects": "All effects",
         "choice_only_unidentified": "Only secret (unidentified) effects",
         "choice_disabled": "Disabled"
+      },
+      "notifications-sound-for-expired-effects": {
+        "name": "Notification sound for expired events",
+        "hint": "Play a sound when an effect expires and notifications are enabled."
+      },
+      "notifications-pause-for-expired-effects": {
+        "name": "Pause clock advancement to first expired effect",
+        "hint": "Only advance the clock to the first expired effect notification and display a dialog to continue or cancel the advancement of the clock."
       }
     },
     "errorMultipleTokensCustomEffect": "You need to have one token selected to apply a custom new effect.",
     "errorNoTokensSelected": "You need to have token(s) selected to apply the effect.",
-    "errorItemNotFound": "Item not found in PF2e message."
+    "errorItemNotFound": "Item not found in PF2e message.",
+    "dialog": {
+      "expired-effects": {
+        "title": "Time Partially Advanced to",
+        "content": {
+          "header": "Time advanced to Expired Effects:",
+          "message-time": "The clock was only advanced by",
+          "message-continue": "Do you want to continue advancing time for the remaining"
+        },
+        "buttons": {
+          "yes": "Yes",
+          "no": "No"
+        }
+      }
+    },
+    "time": {
+      "second": "second",
+      "seconds": "seconds",
+      "minute": "minute",
+      "minutes": "minutes",
+      "hour": "hour",
+      "hours": "hours",
+      "day": "day",
+      "days": "days",
+      "week": "week",
+      "weeks": "weeks"
+    }
   }
 }

--- a/scripts/pf2e-extempore-effects.js
+++ b/scripts/pf2e-extempore-effects.js
@@ -66,6 +66,23 @@ Hooks.on('init', () => {
       'disabled': localize('.settings.notifications-for-expired-effects.choice_disabled'),
     },
   })
+  game.settings.register(MODULE_ID, 'notifications-sound-for-expired-effects', {
+    name: localize('.settings.notifications-sound-for-expired-effects.name'),
+    hint: localize('.settings.notifications-sound-for-expired-effects.hint'),
+    scope: 'world',
+    config: true,
+    type: String,
+    default: '',
+    filePicker: true
+  })
+  game.settings.register(MODULE_ID, 'notifications-pause-for-expired-effects', {
+    name: localize('.settings.notifications-pause-for-expired-effects.name'),
+    hint: localize('.settings.notifications-pause-for-expired-effects.hint'),
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false
+  })
   game.settings.register(MODULE_ID, 'short-stage-badge', {
     name: 'Shorten "Stage 2" to e.g. "[2/6]" in effect badges',
     scope: 'world',
@@ -179,31 +196,74 @@ Hooks.on('renderEffectsPanel', (panel, $html) => {
 
 // Wrap time-change functions so that the GM gets a notification on every Hidden condition that runs out of time
 const onUpdateWorldTime_Wrapper = (wrapped, ...args) => {
-  if (!game.user.isGM) return wrapped(...args)
-  const newWorldTime = args[0]
-  const oldWorldTime = game.time.worldTime
-  // these times are in seconds
-  const timeDeltaS = newWorldTime - oldWorldTime
-  // ignore time updates of 1 round (6 seconds);  because tracking expiration between rounds is very hard and usually doesn't require reminders
-  if (timeDeltaS <= 6) return wrapped(...args)
-  // pf2e has a luxon-based time system, very nice
-  const oldWorldTimeLux = game.pf2e.worldClock.worldTime
-  const newWorldTimeLux = oldWorldTimeLux.plus({ seconds: timeDeltaS })
+  // if (!game.user.isGM) return wrapped(...args) // We have to move this check further down so player clocks stay in sync with GM clocks
+
   const effectsWithDurations = game.pf2e.effectTracker.effects
+  if (!effectsWithDurations.length) return wrapped(...args);
+
+  const oldWorldTime = game.time.worldTime
   const willExpirationDeleteEffects = game.settings.get('pf2e', 'automation.removeExpiredEffects')
   const effectNotificationSetting = game.settings.get(MODULE_ID, 'notifications-for-expired-effects')
+  const requestedNewWorldTime = args[0]
+
+  let newWorldTime = requestedNewWorldTime
+  let expireEffectMessageShown = false
+
+  // We don't want to go further in time than the next effect expiration or the requested time, which ever comes first
+  // Lets iterate through the effects and find the first one that will expire before the requested time, respecting the notification settings
+  if (game.settings.get(MODULE_ID, 'notifications-pause-for-expired-effects') && effectNotificationSetting !== 'disabled') {
+    let firstExpiringEffect = null;
+    for (const effect of effectsWithDurations) {
+      if (effect.isExpired) continue;
+      const isSecretEffect = effect.system.unidentified;
+      if (effectNotificationSetting === 'only_unidentified' && !isSecretEffect) continue;
+
+      if ((oldWorldTime + effect.remainingDuration.remaining) <= requestedNewWorldTime) {
+        firstExpiringEffect = effect;
+        break;
+      }
+    }
+
+    // We found an effect that will expire before the requested time, lets adjust the requested time to that
+    if (firstExpiringEffect) {
+      newWorldTime = oldWorldTime + firstExpiringEffect.remainingDuration.remaining;
+    }
+  }
+
+  // these times are in seconds
+  // ignore time updates of 1 round (6 seconds);  because tracking expiration between rounds is very hard and usually doesn't require reminders
+  const timeDeltaS = newWorldTime - oldWorldTime
+  if (timeDeltaS <= 6 || !game.user.isGM) {
+    args[0] = newWorldTime
+    return wrapped(...args)
+  }
+  // pf2e has a luxon-based time system, very nice
+
+  const oldWorldTimeLux = game.pf2e.worldClock.worldTime
+  const newWorldTimeLux = oldWorldTimeLux.plus({ seconds: timeDeltaS })
+
+  let effectsExpired = []; // lets store effects that expired for notification purposes
+  let lastExpiryTime; // let's store the last expiry time (nicely formated) for the prompt notification
 
   for (const effect of effectsWithDurations) {
     if (effectNotificationSetting === 'disabled') break
     if (effect.isExpired) continue
+
     const isSecretEffect = effect.system.unidentified
     if (!isSecretEffect && effectNotificationSetting === 'only_unidentified') continue
+
     const effectExpiryTimeLux = oldWorldTimeLux.plus({ seconds: effect.remainingDuration.remaining })
     const isEffectGonnaExpireNow = effectExpiryTimeLux.startOf('second') <= newWorldTimeLux.startOf('second')
+
     if (isEffectGonnaExpireNow) {
-      // convert to golarion time
+      effectsExpired.push(effect);
+      expireEffectMessageShown = true;
+
+      // convert to Golarion time
       // TODO rely on system calendar in foundry v13
       const golS = effectExpiryTimeLux.plus({ years: 2700 }).toFormat('yyyy-LL-dd HH:mm:ss')
+      lastExpiryTime = golS;
+
       const durS = `${effect.system.duration.value} ${effect.system.duration.unit}`
       console.log(`${MODULE_NAME} | ${effect.name} expired now!  ID = ${effect.id}`)
       const actor = effect.actor
@@ -245,7 +305,74 @@ const onUpdateWorldTime_Wrapper = (wrapped, ...args) => {
     }
   }
 
-  wrapped(...args)
+  // If there was an expired effect notification, and the user requested to advance time beyond the expiry time,
+  // let's prompt the user if they want to continue to requested time or stop at the expiry time.
+  if (expireEffectMessageShown && newWorldTime < requestedNewWorldTime) {
+    const dialogTitle = `${localize('.dialog.expired-effects.title')} ${lastExpiryTime}`;
+    let dialogContent = `<span><h6>${localize('.dialog.expired-effects.content.header')}</h6><ul>`;
+
+    for (const effect of effectsExpired) dialogContent += `<li>${effect.name} (${effect.actor.name})</li>`;
+
+    dialogContent += `</ul>${localize('.dialog.expired-effects.content.message-time')} ${formatTime(newWorldTime - oldWorldTime)}.</span><span>${localize('.dialog.expired-effects.content.message-continue')}<br>${formatTime(requestedNewWorldTime - newWorldTime)}?</span>`
+
+    promptUserToContinue(requestedNewWorldTime, newWorldTime, oldWorldTime, dialogTitle, dialogContent);
+  }
+
+  // Play the notification sound if a chat notification was made
+  const effectNotificationSoundSetting = game.settings.get(MODULE_ID, 'notifications-sound-for-expired-effects')
+  if (expireEffectMessageShown && effectNotificationSoundSetting.trim() !== '') {
+    foundry.audio.AudioHelper.play({src: effectNotificationSoundSetting});
+  }
+
+  args[0] = newWorldTime
+  wrapped(...args);
+}
+
+function promptUserToContinue(requestedNewWorldTime, newWorldTime, oldWorldTime, dialogTitle, dialogContent) {
+  new foundry.applications.api.DialogV2({
+    window: {
+      title: dialogTitle,
+      icon: 'fa-regular fa-alarm-exclamation'
+    },
+    content: dialogContent,
+    buttons: [{
+      icon: 'fas fa-check',
+      action: "yes",
+      label: localize('.dialog.expired-effects.buttons.yes'),
+      callback: async () => {
+        await game.time.advance(0) // stupid hack, without this the time doesn't advance properly?
+        await game.time.advance((requestedNewWorldTime - newWorldTime));
+      },
+      default: true
+    }, {
+      icon: 'fas fa-times',
+      action: "no",
+      label: localize('.dialog.expired-effects.buttons.no'),
+    }]
+  }).render({force: true});
+}
+
+
+function formatTime(seconds) {
+  const weeks = Math.floor(seconds / (7 * 24 * 60 * 60));
+  seconds %= 7 * 24 * 60 * 60;
+  const days = Math.floor(seconds / (24 * 60 * 60));
+  seconds %= 24 * 60 * 60;
+  const hours = Math.floor(seconds / (60 * 60));
+  seconds %= 60 * 60;
+  const minutes = Math.floor(seconds / 60);
+  seconds %= 60;
+
+  const parts = [];
+  if (weeks > 0) parts.push(`${weeks} ${localize(weeks > 1 ? '.time.weeks' : '.time.week')}`);
+  if (days > 0) parts.push(`${days} ${localize(days > 1 ? '.time.days' : '.time.day')}`);
+  if (hours > 0) parts.push(`${hours} ${localize(hours > 1 ? '.time.hours' : '.time.hour')}`);
+  if (minutes > 0) parts.push(`${minutes} ${localize(minutes > 1 ? '.time.minutes' : '.time.minute')}`);
+  if (seconds > 0) parts.push(`${seconds} ${localize(seconds > 1 ? '.time.seconds' : '.time.second')}`);
+
+  const allParts = parts.join(', ');
+
+  return ` <em>${allParts}</em>`;
 }
 
 const quickAddEmptyEffect = async () => {


### PR DESCRIPTION
Add new settings/features:
 * Play user selectable sound notifications for expired messages
 * Only advance time to the next Expired notification and display a Dialog to prompt GM if they want to continue advancing time or stop.
 * Both new options respect the base "Notifications for expired events", e.g. only play sound/show dialog for Secret effects or disabled completely.